### PR TITLE
Fix: Fetching discs for bands containing an '&' character threw Exception

### DIFF
--- a/src/main/java/com/github/loki/afro/metallum/core/parser/site/DiscSiteParser.java
+++ b/src/main/java/com/github/loki/afro/metallum/core/parser/site/DiscSiteParser.java
@@ -178,7 +178,8 @@ public class DiscSiteParser extends AbstractSiteParser<Disc> {
         String fullString = bandsElement.text();
         for (Element bandElem : bands) {
             String bandLink = bandElem.toString();
-            String bandName = bandElem.text();
+            String bandName = bandElem.text()
+                    .replace("&", "&amp;");
             String bandId = bandLink.substring(0, bandLink.indexOf("\">" + bandName));
             bandId = bandId.substring(bandId.lastIndexOf("/") + 1);
             list.add(new PartialBand(Long.parseLong(bandId), bandName));

--- a/src/test/java/com/github/loki/afro/metallum/search/service/advanced/BandSearchServiceTest.java
+++ b/src/test/java/com/github/loki/afro/metallum/search/service/advanced/BandSearchServiceTest.java
@@ -634,4 +634,12 @@ public class BandSearchServiceTest {
                         "?-? (as 44 X ES$98226)");
     }
 
+    @Test
+    public void escapeSpecialCharactersInBandnameWhenFindingDiscs() throws MetallumException {
+        final Band resultBand = API.getBandById(3540497980L);
+        assertThat(resultBand.getName()).isEqualTo("Rahim Maarof & Whitesteel");
+        // this is where the ampersand character throws an exception if it is not escaped:
+        assertThat(resultBand.getDiscs().size()).isEqualTo(4);
+    }
+
 }


### PR DESCRIPTION
A `StringIndexOutOfBoundsException` got thrown if `parseSplitBands()` was called while the band that had `&` in its name: `bandLink` contains the escaped character because it is the URL, while the `bandName` does not. Therefore, the `bandLink.indexOf("\">" + bandName)` will return `-1`, which in turn will not work for creating a substring one line later.

I wrote a test confirming the assumption. Comment out my fix, run the test, and you'll see the Exception.